### PR TITLE
Make hosting_restapi_check_access more useful

### DIFF
--- a/hosting_restapi.install
+++ b/hosting_restapi.install
@@ -1,13 +1,6 @@
 <?php
 
 /**
- * Implements hook_install().
- */
-function hosting_restapi_install() {
-  drupal_install_schema('hosting_restapi');
-}
-
-/**
  * Implements hook_schema().
  */
 function hosting_restapi_schema() {

--- a/hosting_restapi.module
+++ b/hosting_restapi.module
@@ -61,7 +61,7 @@ function hosting_restapi_hosting_tasks() {
  * If ANY check is accepted, then the check returns TRUE.
  * If no implementations are found, this check returns TRUE.
  *
- * TODO: Implement basic check with an API key variable
+ * hosting_saas has a basic optional API key check.
  */
 function hosting_restapi_check_access($key = NULL, $secret = NULL) {
   $results = module_invoke_all('hosting_restapi_check_access', $key, $secret);

--- a/hosting_restapi.site.inc
+++ b/hosting_restapi.site.inc
@@ -41,7 +41,10 @@ function hosting_restapi_site_get() {
   // FIXME: we want the user to have live updates on the status of the site,
   // so either we grant some temporary access, or we grant to anons.
 
-  hosting_restapi_check_access($_GET['key'], $_GET['secret']);
+  $access = hosting_restapi_check_access($_GET['key'], $_GET['secret']);
+  if (!$access) {
+    throw new Exception(t('Access denied.'));
+  }
 
   $url = $_GET['url'];
   $invoice_id = (isset($_GET['invoice']) ? $_GET['invoice'] : NULL);
@@ -151,7 +154,11 @@ function hosting_restapi_site_get() {
  * we only handle the [url] is rather the subdomain.
  */
 function hosting_restapi_site_post() {
-  hosting_restapi_check_access($_POST['key'], $_POST['secret']);
+  $access = hosting_restapi_check_access($_POST['key'], $_POST['secret']);
+
+  if (!$access) {
+    throw new Exception(t('Access denied.'));
+  }
 
   // TODO : check if URL format is OK (i.e. no spaces, etc)
   $url = check_plain($_POST['url']);


### PR DESCRIPTION
I added a basic API key check in hosting_saas: http://cgit.drupalcode.org/hosting_saas/commit/?id=fb973fa

Right now we don't actually refuse access when there's no TRUE in the hook, we sort of assume the other module will throw an exception. This change allows the module to not have to do that and just return FALSE.

Current installations should not be affected.

I also remove the hook_install() that throws an error on install.
